### PR TITLE
Invert Logo color in dark mode

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -35,7 +35,12 @@ const Header = () => {
   }}
 >
   <Toolbar>
-    <img src="/logg.svg" alt="Logo" style={{ width: 200, marginRight: 12 }} />
+    <img 
+      src="/logg.svg" 
+      alt="Logo" 
+      className={theme.palette.mode === 'dark' ? 'invert' : ''} 
+      style={{ width: 200, marginRight: 12 }} 
+    />
 
     <Typography
       variant="h6"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,3 @@
-
 .board {
     background-color: var(--board-bg);
     transition: background-color 0.3s ease;
@@ -39,4 +38,7 @@
   .light-bg, .dark-bg {
     transition: background-image 0.09s ease-in-out;
   }
-  
+
+  .invert {
+    filter: invert(1);
+  }


### PR DESCRIPTION
# ✅ Changes Made
Added a class to the logo image to invert its color in dark mode for better visibility and contrast.

# ℹ️ Additional Notes

- Initially intended to implement a sticky navbar, but upon checking, it was already implemented by someone else.
- This PR only includes the logo visibility fix.
- Feel free to accept or discard this based on current priorities. Thank you!

# Related Issue
Closes: #31 